### PR TITLE
Update to Sauce Connect v4.3.11

### DIFF
--- a/sauce-connect.rb
+++ b/sauce-connect.rb
@@ -1,8 +1,8 @@
 require "formula"
 class SauceConnect < Formula
   homepage "https://docs.saucelabs.com/reference/sauce-connect/"
-  url "https://saucelabs.com/downloads/sc-4.3.10-osx.zip"
-  sha1 "6ec6f7e2af76a189ed8ceadd31282c5fce1e7dae"
+  url "https://saucelabs.com/downloads/sc-4.3.11-osx.zip"
+  sha1 "5d0aa851d21f3d4a21f298b6a921761c6aa15217"
   def install
     bin.install 'bin/sc'
   end


### PR DESCRIPTION
## Release Notes:

https://support.saucelabs.com/customer/portal/articles/2090612-sauce-connect-4-3-11-released

New Features:
- Users can now specify which DNS SC should use by adding a “--DNS" flag.
- Tunnel VMs now have descriptive domain names for easier debugging.

Stability Upgrades: 
- OpenSSL has been upgraded to 1.0.1p.
- Bug fixes
