### PR TITLE
Use sha256

### DIFF
--- a/sauce-connect.rb
+++ b/sauce-connect.rb
@@ -2,7 +2,7 @@ require "formula"
 class SauceConnect < Formula
   homepage "https://docs.saucelabs.com/reference/sauce-connect/"
   url "https://saucelabs.com/downloads/sc-4.3.16-osx.zip"
-  sha1 "4a25a0f6975b74719621fdd9e646edd08cbf2434"
+  sha256: "c41cfb9c71ef77332bac6757708548ce40a557caf99e77355d05890b86141fee"
   def install
     bin.install 'bin/sc'
   end


### PR DESCRIPTION
Running `brew install sauce-connect` works, but produces this error:

```
$ brew install sauce-connect
Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/raphaeladam-wf/homebrew-sauce-connect/sauce-connect.rb:5:in `<class:SauceConnect>'
Please report this to the raphaeladam-wf/sauce-connect tap!
```

Switch to sha256 so this error no longer appears.

I generated the sha256 with the command `brew fetch sauce-connect`

@travissanderson-wf @seangerhardt-wf @micahbeeman-wf @ianblakeknox-wf 
FYI: @simonhowlett-wf I'm probably going to ask Sauce Labs to add the SHA256 to this page: https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect
